### PR TITLE
Add support for `phoenix_live_view` 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule PhoenixSVG.MixProject do
     [
       {:ex_doc, "~> 0.27", only: :dev, runtime: false},
       {:makeup_eex, "~> 0.1", only: :dev},
-      {:phoenix_live_view, "~> 0.17"}
+      {:phoenix_live_view, "~> 0.17 or ~> 1.0"}
     ]
   end
 


### PR DESCRIPTION
LiveView 1.0 is officially out since a few days, therefore we need to adjust the dependency to allow `phoenix_svg` to work with it !